### PR TITLE
docs: fix typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 LitTex
 ------
 
-An archival markup language for math and the classics; compiles to LaTex and HTML. 
+An archival markup language for math and the classics; compiles to LaTeX and HTML.
 Designed for the [bourbaki project](https://bourbakiproject.com) and the [Litterae](https://greatbooksadventure.com/litterae.html) of the [great books](https://greatbooksadventure.com).
 For more information, see [littex.org](https://littex.org).
 
-Here's an exampe of some LitTex from Halmos' _Naive Set Theory_:
+Here's an example of some LitTex from Halmos' _Naive Set Theory_:
 ```lit
 ¶ ⦊
     ‖ The principal concept of set theory, the one that in

--- a/vscode/littex/README.md
+++ b/vscode/littex/README.md
@@ -1,6 +1,6 @@
 # LitTex
 
-An archival markup language for math and the classics; compiles to LaTex and HTML. 
+An archival markup language for math and the classics; compiles to LaTeX and HTML.
 Designed for the [bourbaki project](https://bourbakiproject.com) and the [Litterae](https://greatbooksadventure.com/litterae.html) of the [great books](https://greatbooksadventure.com).
 For more information, see [littex.org](https://littex.org).
 


### PR DESCRIPTION
## Summary
- fix LaTeX typo in main and VS Code README
- correct misspelling of "example" in main README

## Testing
- `go test ./...` *(fails: unable to fetch modules)*

------
https://chatgpt.com/codex/tasks/task_e_685ee38caed08329aa51fc5a3e5fef09