### PR TITLE
Fix comment typo

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -142,7 +142,7 @@ func litReplace(s string) string {
 		}
 		return out
 	})
-	// all to get the escape functionalityj
+       // all to get the escape functionality
 	s = strings.Replace(s, "\\⦉", "⦉", -1)
 
 	// Update: Unfortunately the below doesn't work


### PR DESCRIPTION
## Summary
- fix a small typo in `parse.go` comment

## Testing
- `go test ./...` *(fails: unable to fetch modules)*

------
https://chatgpt.com/codex/tasks/task_e_685ee39360c88329a176a43d30d676e2